### PR TITLE
aommy/fix/export-to-csv

### DIFF
--- a/src/comma_fixer/fixer.py
+++ b/src/comma_fixer/fixer.py
@@ -153,6 +153,7 @@ class Fixer:
         """
         processed_csv: str = ""
         invalid_entries: list[InvalidEntry] = list()
+        first_row_is_header = skip_first_line
 
         line_count = 0
         with open(filepath) as file:
@@ -189,6 +190,7 @@ class Fixer:
             schema=self.schema,
             processed_csv=processed_csv,
             invalid_entries=invalid_entries,
+            skip_first_line=first_row_is_header,
         )
 
         print(

--- a/src/comma_fixer/parsed.py
+++ b/src/comma_fixer/parsed.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 from dataclasses import dataclass
 from typing import TypeAlias
 
@@ -8,6 +9,7 @@ from comma_fixer.schema import Schema
 
 InvalidEntry: TypeAlias = tuple[int, str]
 ParsedEntry: TypeAlias = list[str]
+logger = logging.getLogger("Parsed Logs")
 
 
 @dataclass
@@ -16,30 +18,42 @@ class Parsed:
     Parsed class produced from calling `fix_file` in Fixer.
 
     Attributes:
-        schema (Schema): Schema of dataset.
-        processed (str): CSV of dataset stored as a string.
-        invalid_line_numbers (list[InvalidEntry]): List of invalid entries containing line number and entry.
+        _schema (Schema): Schema of dataset.
+        _processed (str): CSV of dataset stored as a string.
+        _invalid_line_numbers (list[InvalidEntry]): List of invalid entries containing line number and entry.
+        _skip_first_line (bool): Whether the original CSV file had headers as the first row.
     """
 
     _schema: Schema
     _processed: str
     _invalid_entries: list[InvalidEntry]
+    _skip_first_line: bool
 
     @classmethod
     def new(
-        cls, schema: Schema, processed_csv: str, invalid_entries: list[InvalidEntry]
+        cls,
+        schema: Schema,
+        processed_csv: str,
+        invalid_entries: list[InvalidEntry],
+        skip_first_line: bool,
     ) -> "Parsed":
         """
         Creates an empty Parsed object with specified Schema.
 
         Args:
             schema (Schema): Schema of dataset.
+            processed_csv (str): Processed CSV as a string.
+            invalid_entries (list[InvalidEntry]): List of invalid entries with line index.
+            skip_first_line (bool): Whether the first line was skipped in original input file.
 
         Returns:
             Parsed. Parsed object with specified schema.
         """
         return Parsed(
-            _schema=schema, _processed=processed_csv, _invalid_entries=invalid_entries
+            _schema=schema,
+            _processed=processed_csv,
+            _invalid_entries=invalid_entries,
+            _skip_first_line=skip_first_line,
         )
 
     def export_to_csv_best_effort(self, filepath: str):
@@ -50,9 +64,12 @@ class Parsed:
         """
         processed_to_csv = pd.DataFrame(self._schema.get_series_dict())
         for line_number, line in enumerate(self._processed.split("\n")):
+            if self._skip_first_line:
+                line_number += 1
             if (line_number, line) not in self._invalid_entries:
                 parsed_csv = list(csv.reader([line]))[0]
                 processed_to_csv.loc[len(processed_to_csv)] = parsed_csv
+        logger.info(processed_to_csv.info())
         return processed_to_csv.to_csv(filepath, index=False)
 
     def print_all_invalid_entries(self):


### PR DESCRIPTION
Fixed incorrect indexing when exporting to CSV if the input file's first row was skipped, leading to invalid entries being exported.